### PR TITLE
do not automatically start the Store if the :use_store config is false

### DIFF
--- a/lib/ueberauth/strategy/application.ex
+++ b/lib/ueberauth/strategy/application.ex
@@ -4,14 +4,20 @@ defmodule Ueberauth.Strategy.Passwordless.Application do
   alias Ueberauth.Strategy.Passwordless
 
   def start(_type, opts) do
-    if Passwordless.config(:use_store), do: start_store(opts)
+    :use_store
+    |> Passwordless.config()
+    |> maybe_start_store(opts)
   end
 
-  defp start_store(opts) do
+  defp maybe_start_store(true, opts) do
     children = [
       {Ueberauth.Strategy.Passwordless.Store, opts}
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)
+  end
+
+  defp maybe_start_store(false, _opts) do
+    {:ok, self()}
   end
 end


### PR DESCRIPTION
With the current implementation of the `Application` module, the `Store` is always automatically started but never used if the `:use_store` configuration has been set to `false`. If the `Store` is never used and we do not want use it, then it should not be started in the first place.

This is because no other option in the code was given in the previous implementation of the `Application` module in the `start_2` function.