### PR TITLE
Encode email url parameter

### DIFF
--- a/lib/ueberauth/strategy/passwordless.ex
+++ b/lib/ueberauth/strategy/passwordless.ex
@@ -184,7 +184,7 @@ defmodule Ueberauth.Strategy.Passwordless do
   end
 
   defp set_redirect_params(conn, redirect_url) do
-    email = conn.private[:passwordless_email]
+    email = conn.private[:passwordless_email] |> URI.encode_www_form()
     "#{redirect_url}?email=#{email}"
   end
 

--- a/test/ueberauth_passwordless_test.exs
+++ b/test/ueberauth_passwordless_test.exs
@@ -25,7 +25,15 @@ defmodule UeberauthPasswordlessTest do
         conn("get", "/auth/passwordless", %{email: "foo@bar.com"})
         |> Passwordless.handle_request!()
 
-      assert get_resp_header(conn, "location") == ["/?email=foo@bar.com"]
+      assert get_resp_header(conn, "location") == ["/?email=foo%40bar.com"]
+    end
+
+    test "encodes the email url parameter" do
+      conn =
+        conn("get", "/auth/passwordless", %{email: "foo+bar@baz.com"})
+        |> Passwordless.handle_request!()
+
+      assert get_resp_header(conn, "location") == ["/?email=foo%2Bbar%40baz.com"]
     end
 
     test "redirects to a provided url" do
@@ -33,7 +41,7 @@ defmodule UeberauthPasswordlessTest do
         conn("get", "/auth/passwordless", %{email: "foo@bar.com", redirect_url: "/foo"})
         |> Passwordless.handle_request!()
 
-      assert get_resp_header(conn, "location") == ["/foo?email=foo@bar.com"]
+      assert get_resp_header(conn, "location") == ["/foo?email=foo%40bar.com"]
     end
 
     test "returns an error if no email was provided" do


### PR DESCRIPTION
Some characters like the `+` will get lost if they are not encoded properly.